### PR TITLE
fix: don't fetch namespace keys when creating value in case namespace does not exist

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -82,7 +82,7 @@ class Api {
 
     createValue = async (namespace, key, value) => {
         const d2 = await getInstance()
-        const resName = await d2.dataStore.get(namespace)
+        const resName = await d2.dataStore.get(namespace, false)
         const response = await resName.set(key, value, true)
         this.cache.set(namespace, key, {
             length: 0,


### PR DESCRIPTION
[Porting this app to the app platform](https://github.com/dhis2/datastore-app/pull/17) required updating `d2` from `v27.0.0-5` to `v31.9.0`. Between these versions, the way `d2.dataStore.get` works changed - in `v27` attempting to fetch a non-existent [namespace does not result in an error](https://github.com/dhis2/d2/blob/v27.0.0-5/src/datastore/DataStore.js#L59-L67) but it does [in `v31`](https://github.com/dhis2/d2/blob/cb70b1fcbcaf1a648b3a84edfd7a9e81c3782e5b/src/datastore/BaseStore.js#L49-L68). 

As [this comment](https://github.com/dhis2/datastore-app/blob/3012cb73aef845491d2f3446d16ae89b7a55ebf1/src/actions/index.js#L441-L445) helpfully explains, the `createValue` action is used both for creating keys and namespaces. The `createValue` action itself calls the `createValue` method of the `API` class and this is where our bug lies:
https://github.com/dhis2/datastore-app/blob/3012cb73aef845491d2f3446d16ae89b7a55ebf1/src/utils/api.js#L83-L92

If `d2` is at version `31.9.0`, then when using the `createValue` action is used to create a namespace the `await d2.dataStore.get(namespace)` line will throw the error `The namespace 'Namespace' was not found`.

Setting the second argument of `dataStore.get` to false (corresponding to the `autoLoad` parameter) [will return an instance of `DataStoreNamespace`](https://github.com/dhis2/d2/blob/v27.0.0-5/src/datastore/DataStore.js#L47-L51), restoring the behaviour of `v27`.