### PR TITLE
fix: don't fetch namespace keys when creating value in case namespace does not exist (2.36.0)

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -82,7 +82,7 @@ class Api {
 
     createValue = async (namespace, key, value) => {
         const d2 = await getInstance()
-        const resName = await d2.dataStore.get(namespace)
+        const resName = await d2.dataStore.get(namespace, false)
         const response = await resName.set(key, value, true)
         this.cache.set(namespace, key, {
             length: 0,


### PR DESCRIPTION
2.36.0 backport of https://github.com/dhis2/datastore-app/pull/32