### PR TITLE
fix: use error.httpStatusCode instead of error.status for d2 errors

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -383,7 +383,7 @@ export function fetchAndToggleNamespace(namespace, openNamespace = false) {
             })
             .then(() => dispatch(toggleNamespace(namespace, openNamespace)))
             .catch(error => {
-                if (error.status === 404) {
+                if (error.httpStatusCode === 404) {
                     // If not found, we remove the namespace from UI
                     return dispatch(receiveDeleteNamespace(namespace))
                 } else if (error) {
@@ -545,7 +545,7 @@ export function deleteKey(namespace, key) {
             })
             .then(() => dispatch(fetchKeys(namespace)))
             .catch(error => {
-                if (error.status === 404) {
+                if (error.httpStatusCode === 404) {
                     // If not found, we remove the namespace from UI
                     dispatch(receiveDeleteNamespace(namespace))
                 } else if (error) {


### PR DESCRIPTION
[Porting this app to the app platform](https://github.com/dhis2/datastore-app/pull/17) required updating `d2` from `v27.0.0-5` to `v31.9.0`. Between these versions, the way `d2` returns API related errors changed - in `v27` the http status of an API error is stored in the `status` field while in `v31` it is stored in the `httpStatusCode` field.

This PR replaces every instance of `error.status` with `error.httpStatusCode`.