### PR TITLE
fix: use error.httpStatusCode instead of error.status for d2 errors (2.36.0)

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -383,7 +383,7 @@ export function fetchAndToggleNamespace(namespace, openNamespace = false) {
             })
             .then(() => dispatch(toggleNamespace(namespace, openNamespace)))
             .catch(error => {
-                if (error.status === 404) {
+                if (error.httpStatusCode === 404) {
                     // If not found, we remove the namespace from UI
                     return dispatch(receiveDeleteNamespace(namespace))
                 } else if (error) {
@@ -545,7 +545,7 @@ export function deleteKey(namespace, key) {
             })
             .then(() => dispatch(fetchKeys(namespace)))
             .catch(error => {
-                if (error.status === 404) {
+                if (error.httpStatusCode === 404) {
                     // If not found, we remove the namespace from UI
                     dispatch(receiveDeleteNamespace(namespace))
                 } else if (error) {


### PR DESCRIPTION
2.36.0 backport of https://github.com/dhis2/datastore-app/pull/35