### PR TITLE
fix: obtain datastore values directly instead of from metadata 

### DIFF
--- a/src/constants/apiUrls.js
+++ b/src/constants/apiUrls.js
@@ -1,1 +1,0 @@
-export const API_URL = 'https://debug.dhis2.org/dev/api'

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,5 +1,4 @@
 import { getInstance } from 'd2'
-import { API_URL } from '../constants/apiUrls'
 
 export class Cache {
     constructor() {
@@ -108,5 +107,5 @@ class Api {
     }
 }
 
-const apiInstance = new Api(API_URL)
+const apiInstance = new Api()
 export default apiInstance

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -63,20 +63,15 @@ class Api {
             return this.cache.get(namespace, key)
         }
 
-        const result = await this.getMetaData(namespace, key)
-        const jsonLength = result.value.length
+        const d2 = await getInstance()
+        const dataStore = await d2.dataStore.get(namespace, false)
+        const res = await dataStore.get(key)
         const value = {
-            length: jsonLength,
-            value: JSON.parse(result.value),
+            value: res,
+            length: JSON.stringify(res).length,
         }
         this.cache.set(namespace, key, value)
         return value
-    }
-
-    getMetaData = async (namespace, key) => {
-        const d2 = await getInstance()
-        const response = await d2.dataStore.get(namespace, false)
-        return response.getMetaData(key)
     }
 
     createValue = async (namespace, key, value) => {


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-10794.

The namespace protection introduced by https://github.com/dhis2/dhis2-core/pull/7520 has changed the schema for `/api/dataStore/<namespace>/<key>/metaData`. The result of that API no longer has the `value` field that the datastore app expects.