### PR TITLE
fix: catch errors when formatting json editor content [DHIS2-14202]

### DIFF
--- a/src/components/utils/JSONEditor.js
+++ b/src/components/utils/JSONEditor.js
@@ -119,11 +119,22 @@ export class JSONEditor extends Component {
 
         if (this.editor.getMode() !== 'tree') {
             if (compact) {
-                this.editor.compact()
+                try {
+                    this.editor.compact()
+                } catch (e) {
+                    console.error(
+                        'An error occurred while formatting JSON (compact)',
+                        e
+                    )
+                }
             }
 
             if (format) {
-                this.editor.format()
+                try {
+                    this.editor.format()
+                } catch (e) {
+                    console.error('An error occurred while formatting JSON', e)
+                }
             }
         }
 


### PR DESCRIPTION
FIxes [DHIS2-14202](https://dhis2.atlassian.net/browse/DHIS2-14202)

This was encountered in a Latin American country during penetration testing, and even though it's not a security vulnerability they would like it fixed.  We will try to talk them down from this stance, but would be good to fix this anyway.

@tomzemp I saw you picked this issue up already, feel free to discard this solution if you have a different one.

This will also need to be forward-ported