### PR TITLE
fix: modifications to style, editor and sharing action components

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-02-13T07:30:11.793Z\n"
-"PO-Revision-Date: 2025-02-13T07:30:11.794Z\n"
+"POT-Creation-Date: 2025-03-12T12:25:26.754Z\n"
+"PO-Revision-Date: 2025-03-12T12:25:26.755Z\n"
 
 msgid "An error has occurred"
 msgstr "An error has occurred"
@@ -34,6 +34,18 @@ msgstr "Special characters are not allowed in this field"
 
 msgid "Alphanumeric characters only"
 msgstr "Alphanumeric characters only"
+
+msgid "Close"
+msgstr "Close"
+
+msgid "Save"
+msgstr "Save"
+
+msgid "Save changes"
+msgstr "Save changes"
+
+msgid "New Key"
+msgstr "New Key"
 
 msgid "Cancel"
 msgstr "Cancel"
@@ -74,15 +86,6 @@ msgstr "There was a problem updating the key - {{error}}"
 msgid "There was a problem - {{error}}"
 msgstr "There was a problem - {{error}}"
 
-msgid "Close"
-msgstr "Close"
-
-msgid "Save"
-msgstr "Save"
-
-msgid "Save changes"
-msgstr "Save changes"
-
 msgid "Loading"
 msgstr "Loading"
 
@@ -94,9 +97,6 @@ msgstr "Key '{{selectedKey}}' deleted successfully"
 
 msgid "There was a problem deleting this key - {{error}}"
 msgstr "There was a problem deleting this key - {{error}}"
-
-msgid "New Key"
-msgstr "New Key"
 
 msgid "Search keys"
 msgstr "Search keys"
@@ -136,6 +136,9 @@ msgstr "Actions"
 
 msgid "No items found"
 msgstr "No items found"
+
+msgid "There was a problem fetching this key's ID"
+msgstr "There was a problem fetching this key's ID"
 
 msgid "Share"
 msgstr "Share"

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -43,10 +43,12 @@
 
 .keysPanel {
     height: 100%;
+    width: 100%;
 }
 
 .editorPanel {
     height: 100%;
+    width: 100%;
 }
 
 /* page header */
@@ -60,79 +62,49 @@
     border-block-end: 1px solid var(--colors-grey300);
 }
 
-.secondPageHeader {
-    width: fit-content;
-    color: var(--colors-grey800);
-    text-decoration: none;
-    align-self: center;
-    font-size: 14px;
-    padding: var(--spacers-dp12) var(--spacers-dp8);
-    border-radius: 7px;
-}
-
-.secondPageHeader:hover {
-    background-color: var(--colors-grey300);
-    text-decoration: underline;
-}
-.secondPageHeader span {
-    display: grid;
-    grid-template-columns: auto auto;
-    gap: var(--spacers-dp8);
-}
-
 /* panel header */
 
 .panelHeader {
     height: 50px;
     padding: 0 0.5em;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+    display: grid;
+    gap: var(--spacers-dp4);
+    grid-template-columns: auto auto;
     align-items: center;
     border-block-end: 1px solid var(--colors-grey300);
     border-inline-end: 1px solid var(--colors-grey300);
 }
 
-.keysPanelHeader {
-    font-weight: 500;
-    font-size: 15px;
-    color: var(--colors-grey900);
-}
-
-.keysHeaderLabel {
+.keysPanelHeaderLabel {
     display: flex;
     gap: var(--spacers-dp4);
+    font-size: 15px;
+    flex-wrap: wrap;
+    width: fit-content;
 }
 
-.keysHeaderLink {
+.dataStoreLink {
     font-size: 15px;
     color: var(--colors-grey600);
     text-decoration: none;
 }
 
-.keysHeaderLink:hover {
+.dataStoreLink:hover {
     color: var(--colors-grey900);
     text-decoration: underline;
 }
 
-.keysHeaderLabelDivider {
+.labelDivider {
     color: var(--colors-grey600);
+}
+
+.namespaceLabel {
+    font-weight: 500;
+    color: var(--colors-grey900);
 }
 
 .keysPanelMidSection {
     padding: var(--spacers-dp8);
-}
-
-.emptyEditorPanelHeader {
-    font-style: italic;
-    font-size: 15px;
-    color: var(--colors-grey600);
-}
-
-.editorPanelHeader {
-    font-size: 15px;
-    color: var(--colors-grey800);
-    font-weight: 500;
 }
 
 /* namespace view */
@@ -155,12 +127,12 @@
     grid-column: 1 / 2;
 }
 
-.createButton {
+.createNamespace {
     grid-column: 5;
     color: var(--colors-grey600);
 }
 
-.createButton button {
+.createButton {
     width: fit-content;
     float: right;
 }
@@ -192,13 +164,26 @@
 
 /* edit page */
 
-.editButtons {
+.emptyEditorPanelHeader {
+    font-style: italic;
+    font-size: 15px;
+    color: var(--colors-grey600);
+}
+
+.editorPanelKeysLabel {
+    font-size: 15px;
+    color: var(--colors-grey800);
+    font-weight: 500;
+}
+
+.editorPanelEditButtons {
     display: grid;
     grid-template-columns: auto auto;
     gap: var(--spacers-dp4);
+    justify-content: end;
 }
 
-.editButtons button {
+.editorPanelEditButtons button {
     width: fit-content;
 }
 
@@ -225,4 +210,38 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacers-dp8);
+}
+
+@media screen and (max-width: 600px) {
+    .panelHeader {
+        height: 75px;
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacers-dp8);
+        align-items: flex-start;
+        justify-content: center;
+        margin: 0.5em 0;
+    }
+
+    .keysPanelHeaderLabel {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--spacers-dp4);
+    }
+    .namespaceLabel {
+        display: flex;
+        flex-direction: column;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    .midSection {
+        display: flex;
+        flex-direction: column-reverse;
+        gap: var(--spacers-dp8);
+    }
+    .createButton {
+        width: 100%;
+        float: none;
+    }
 }

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -214,7 +214,7 @@
 
 @media screen and (max-width: 600px) {
     .panelHeader {
-        height: 75px;
+        height: 65px;
         display: flex;
         flex-direction: column;
         gap: var(--spacers-dp8);

--- a/src/components/fields/TextField.tsx
+++ b/src/components/fields/TextField.tsx
@@ -4,6 +4,7 @@ import {
     hasValue,
     composeValidators,
     alphaNumeric,
+    createMaxCharacterLength,
 } from '@dhis2/ui'
 import React from 'react'
 import i18n from '../../locales'
@@ -32,7 +33,11 @@ const TextField = ({
             component={InputFieldFF}
             required={required}
             label={label}
-            validate={composeValidators(hasValue, customAlphaNumeric)}
+            validate={composeValidators(
+                hasValue,
+                customAlphaNumeric,
+                createMaxCharacterLength(255)
+            )}
             initialFocus={initialFocus}
             helpText={i18n.t('Alphanumeric characters only')}
         />

--- a/src/components/header/EditPanelHeader.tsx
+++ b/src/components/header/EditPanelHeader.tsx
@@ -1,0 +1,52 @@
+import { Button } from '@dhis2/ui'
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import classes from '../../App.module.css'
+import i18n from '../../locales'
+import PanelHeader from './PanelHeader'
+
+type EditPanelHeaderProps = {
+    handleClose: () => void
+    disableCloseButton: boolean
+    handleUpdate: () => void
+    loading: boolean
+}
+
+const EditPanelHeader = ({
+    handleClose,
+    disableCloseButton,
+    handleUpdate,
+    loading,
+}: EditPanelHeaderProps) => {
+    const { key } = useParams()
+    return (
+        <PanelHeader>
+            <span className={classes.editorPanelKeysLabel}>{key}</span>
+            <div className={classes.editorPanelEditButtons}>
+                <Button
+                    small
+                    aria-label={i18n.t('Close')}
+                    name="close"
+                    onClick={() => handleClose()}
+                    title={i18n.t('Close')}
+                    disabled={disableCloseButton}
+                >
+                    {i18n.t('Close')}
+                </Button>
+                <Button
+                    small
+                    aria-label={i18n.t('Save')}
+                    name="save"
+                    onClick={() => handleUpdate()}
+                    title={i18n.t('Save')}
+                    primary
+                    loading={loading}
+                >
+                    {i18n.t('Save changes')}
+                </Button>
+            </div>
+        </PanelHeader>
+    )
+}
+
+export default EditPanelHeader

--- a/src/components/header/KeysPanelHeader.tsx
+++ b/src/components/header/KeysPanelHeader.tsx
@@ -1,0 +1,40 @@
+import { IconAdd16, colors } from '@dhis2/ui'
+import React from 'react'
+import { Link, useParams } from 'react-router-dom'
+import classes from '../../App.module.css'
+import { DATASTORE, USERDATASTORE } from '../../constants/constants'
+import i18n from '../../locales'
+import PanelHeader from '../header/PanelHeader'
+import CreateButton from '../sections/CreateButton'
+
+const KeysPanelHeader = ({
+    setOpenCreateModal,
+}: {
+    setOpenCreateModal: React.Dispatch<React.SetStateAction<boolean>>
+}) => {
+    const { namespace: currentNamespace, store } = useParams()
+    return (
+        <PanelHeader>
+            <div className={classes.keysPanelHeaderLabel}>
+                <Link to={`/${store}`} className={classes.dataStoreLink}>
+                    <span>
+                        {store === DATASTORE && 'DataStore'}
+                        {store === USERDATASTORE && 'UserDataStore'}
+                    </span>
+                </Link>
+                <span className={classes.labelDivider}>/</span>
+
+                <span className={classes.namespaceLabel}>
+                    {currentNamespace}
+                </span>
+            </div>
+            <CreateButton
+                label={i18n.t('New Key')}
+                handleClick={() => setOpenCreateModal(true)}
+                icon={<IconAdd16 color={colors.grey600} />}
+            />
+        </PanelHeader>
+    )
+}
+
+export default KeysPanelHeader

--- a/src/components/panels/EditorPanel.tsx
+++ b/src/components/panels/EditorPanel.tsx
@@ -23,14 +23,14 @@ const EditorPanel = () => {
     const { store } = useParams()
 
     return (
-        <div>
+        <>
             {store === DATASTORE && (
                 <EditSection query={dataStoreKeyValuesQuery} />
             )}
             {store === USERDATASTORE && (
                 <EditSection query={userDataStoreKeyValuesQuery} />
             )}
-        </div>
+        </>
     )
 }
 

--- a/src/components/panels/EmptyEditorPanel.tsx
+++ b/src/components/panels/EmptyEditorPanel.tsx
@@ -12,9 +12,7 @@ const EmptyEditorPanel = () => {
                     <i>{i18n.t('Choose a key to start editing')}</i>
                 </span>
             </PanelHeader>
-            <div>
-                <Editor value={''} />
-            </div>
+            <Editor active={false} />
         </div>
     )
 }

--- a/src/components/panels/EmptyEditorPanel.tsx
+++ b/src/components/panels/EmptyEditorPanel.tsx
@@ -6,14 +6,14 @@ import Editor from '../sections/Editor'
 
 const EmptyEditorPanel = () => {
     return (
-        <div>
+        <>
             <PanelHeader>
                 <span className={classes.emptyEditorPanelHeader}>
                     <i>{i18n.t('Choose a key to start editing')}</i>
                 </span>
             </PanelHeader>
             <Editor active={false} />
-        </div>
+        </>
     )
 }
 

--- a/src/components/sections/CreateButton.tsx
+++ b/src/components/sections/CreateButton.tsx
@@ -6,11 +6,17 @@ type CreateButtonProps = {
     label: string
     handleClick: () => void
     icon: React.ReactElement
+    className?: string
 }
 
-const CreateButton = ({ label, handleClick, icon }: CreateButtonProps) => {
+const CreateButton = ({
+    label,
+    handleClick,
+    icon,
+    className,
+}: CreateButtonProps) => {
     return (
-        <div className={classes.createButton}>
+        <div className={className}>
             <Button
                 small
                 aria-label={label}
@@ -18,6 +24,7 @@ const CreateButton = ({ label, handleClick, icon }: CreateButtonProps) => {
                 name="create"
                 onClick={handleClick}
                 title={label}
+                className={classes.createButton}
             >
                 {label}
             </Button>

--- a/src/components/sections/EditSection.tsx
+++ b/src/components/sections/EditSection.tsx
@@ -135,6 +135,7 @@ const EditSection = ({ query }) => {
             <Editor
                 value={loading ? i18n.t('Loading') : value}
                 handleChange={handleEditorChange}
+                active
             />
         </div>
     )

--- a/src/components/sections/EditSection.tsx
+++ b/src/components/sections/EditSection.tsx
@@ -125,7 +125,7 @@ const EditSection = ({ query }) => {
     }, [store, namespace, key, refetch])
 
     return (
-        <div>
+        <>
             <EditPanelHeader
                 handleClose={handleClose}
                 disableCloseButton={updateLoading}
@@ -137,7 +137,7 @@ const EditSection = ({ query }) => {
                 handleChange={handleEditorChange}
                 active
             />
-        </div>
+        </>
     )
 }
 

--- a/src/components/sections/EditSection.tsx
+++ b/src/components/sections/EditSection.tsx
@@ -1,11 +1,9 @@
 import { useAlert, useDataEngine, useDataQuery } from '@dhis2/app-runtime'
-import { Button } from '@dhis2/ui'
 import React, { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import classes from '../../App.module.css'
 import useCustomAlert from '../../hooks/useCustomAlert'
 import i18n from '../../locales'
-import PanelHeader from '../header/PanelHeader'
+import EditPanelHeader from '../header/EditPanelHeader'
 import Editor from './Editor'
 
 const EditSection = ({ query }) => {
@@ -124,40 +122,16 @@ const EditSection = ({ query }) => {
             key,
             namespace,
         })
-    }, [store, namespace, key])
+    }, [store, namespace, key, refetch])
 
     return (
         <div>
-            <PanelHeader>
-                {data && (
-                    <>
-                        <span className={classes.editorPanelHeader}>{key}</span>
-                        <div className={classes.editButtons}>
-                            <Button
-                                small
-                                aria-label={i18n.t('Close')}
-                                name="close"
-                                onClick={() => handleClose()}
-                                title={i18n.t('Close')}
-                                disabled={updateLoading}
-                            >
-                                {i18n.t('Close')}
-                            </Button>
-                            <Button
-                                small
-                                aria-label={i18n.t('Save')}
-                                name="save"
-                                onClick={() => handleUpdate()}
-                                title={i18n.t('Save')}
-                                primary
-                                loading={!editError && updateLoading}
-                            >
-                                {i18n.t('Save changes')}
-                            </Button>
-                        </div>
-                    </>
-                )}
-            </PanelHeader>
+            <EditPanelHeader
+                handleClose={handleClose}
+                disableCloseButton={updateLoading}
+                handleUpdate={handleUpdate}
+                loading={!editError && updateLoading}
+            />
             <Editor
                 value={loading ? i18n.t('Loading') : value}
                 handleChange={handleEditorChange}

--- a/src/components/sections/Editor.tsx
+++ b/src/components/sections/Editor.tsx
@@ -4,10 +4,11 @@ import React from 'react'
 
 type EditorProps = {
     handleChange?: (value: string, viewUpdate: ViewUpdate) => void
-    value: string
+    value?: string
+    active: boolean
 }
 
-const Editor = ({ value, handleChange }: EditorProps) => {
+const Editor = ({ value, handleChange, active }: EditorProps) => {
     return (
         <CodeMirror
             theme={'dark'}
@@ -15,6 +16,9 @@ const Editor = ({ value, handleChange }: EditorProps) => {
             height="100vh"
             extensions={[json()]}
             onChange={handleChange}
+            readOnly={!active}
+            editable={active}
+            autoFocus={active}
         />
     )
 }

--- a/src/components/sections/KeysDataSection.tsx
+++ b/src/components/sections/KeysDataSection.tsx
@@ -1,21 +1,18 @@
 import { useDataEngine, useDataQuery } from '@dhis2/app-runtime'
-import { IconAdd16, colors } from '@dhis2/ui'
 import React, { useEffect, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import classes from '../../App.module.css'
-import { DATASTORE, USERDATASTORE } from '../../constants/constants'
 import useCustomAlert from '../../hooks/useCustomAlert'
 import useSearchFilter from '../../hooks/useSearchFilter'
 import i18n from '../../locales'
 import ErrorNotice from '../error/ErrorNotice'
 import KeyField from '../fields/KeyField'
 import SearchField from '../fields/SearchField'
-import PanelHeader from '../header/PanelHeader'
+import KeysPanelHeader from '../header/KeysPanelHeader'
 import CenteredLoader from '../loader/Loader'
 import CreateModal from '../modals/CreateModal'
 import DeleteModal from '../modals/DeleteModal'
 import ItemsTable from '../table/ItemsTable'
-import CreateButton from './CreateButton'
 
 interface QueryResults {
     results: []
@@ -134,26 +131,7 @@ const KeysDataSection = ({ query }) => {
 
     return (
         <>
-            <PanelHeader>
-                <div className={classes.keysHeaderLabel}>
-                    <Link to={`/${store}`} className={classes.keysHeaderLink}>
-                        <span>
-                            {store === DATASTORE && 'DataStore'}
-                            {store === USERDATASTORE && 'UserDataStore'}
-                        </span>
-                    </Link>
-                    <span className={classes.keysHeaderLabelDivider}>/</span>
-
-                    <span className={classes.keysPanelHeader}>
-                        {currentNamespace}
-                    </span>
-                </div>
-                <CreateButton
-                    label={i18n.t('New Key')}
-                    handleClick={() => setOpenCreateModal(true)}
-                    icon={<IconAdd16 color={colors.grey600} />}
-                />
-            </PanelHeader>
+            <KeysPanelHeader setOpenCreateModal={setOpenCreateModal} />
             <div className={classes.keysPanelMidSection}>
                 <SearchField
                     searchTerm={searchTerm}

--- a/src/components/sections/NamespaceDataSection.tsx
+++ b/src/components/sections/NamespaceDataSection.tsx
@@ -120,6 +120,7 @@ const NamespaceDataSection = ({ query }) => {
                     label={i18n.t('New namespace')}
                     handleClick={() => setOpenCreateModal(true)}
                     icon={<IconAdd24 color={colors.grey600} />}
+                    className={classes.createNamespace}
                 />
             </div>
             <div>

--- a/src/components/table/ItemsTable.tsx
+++ b/src/components/table/ItemsTable.tsx
@@ -45,12 +45,14 @@ const ItemsTable = ({
     }, [key])
 
     return (
-        <div>
+        <>
             {tableData && (
-                <DataTable layout="fixed" scrollHeight="75vh">
+                <DataTable scrollHeight="75vh">
                     <TableHead>
                         <DataTableRow>
                             <DataTableColumnHeader
+                                fixed
+                                top={'0'}
                                 width={currentNamespace ? '85%' : '90%'}
                             >
                                 <span className={classes.columnHeader}>
@@ -58,6 +60,8 @@ const ItemsTable = ({
                                 </span>
                             </DataTableColumnHeader>
                             <DataTableColumnHeader
+                                fixed
+                                top={'0'}
                                 width={currentNamespace ? '15%' : '10%'}
                             >
                                 <span className={classes.columnHeader}>
@@ -135,7 +139,7 @@ const ItemsTable = ({
                     </TableBody>
                 </DataTable>
             )}
-        </div>
+        </>
     )
 }
 

--- a/src/components/table/SharingAction.tsx
+++ b/src/components/table/SharingAction.tsx
@@ -1,24 +1,48 @@
 import { useDataQuery } from '@dhis2/app-runtime'
-import { SharingDialog } from '@dhis2/ui'
+import { CircularLoader, SharingDialog } from '@dhis2/ui'
 import { IconShare16 } from '@dhis2/ui-icons'
 import { Button } from '@dhis2-ui/button'
 import React, { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { DATASTORE } from '../../constants/constants'
+import useCustomAlert from '../../hooks/useCustomAlert'
 import i18n from '../../locales'
 
 interface SharingActionProps {
     dataStoreKey: string
 }
 
-export default function SharingAction({ dataStoreKey }: SharingActionProps) {
-    const [openSharingDialog, setOpenSharingDialog] = useState(false)
+export default function SharingAction({
+    dataStoreKey,
+}: Readonly<SharingActionProps>) {
     const { namespace: currentNamespace } = useParams()
-    const { data: keyMetaData } = useDataQuery({
-        metadata: {
-            resource: `dataStore/${currentNamespace}/${dataStoreKey}/metaData`,
+    const [openSharingDialog, setOpenSharingDialog] = useState(false)
+    const [keyID, setKeyID] = useState(null)
+    const { showError } = useCustomAlert()
+
+    const { loading, refetch } = useDataQuery(
+        {
+            metadata: {
+                resource: `dataStore/${currentNamespace}/${dataStoreKey}/metaData`,
+            },
         },
-    })
+        {
+            lazy: true,
+            onComplete(data) {
+                if (data?.['metadata']?.['id']) {
+                    setKeyID(data['metadata']['id'])
+                    setOpenSharingDialog(true)
+                }
+            },
+            onError() {
+                showError(i18n.t("There was a problem fetching this key's ID"))
+            },
+        }
+    )
+
+    if (loading) {
+        return <CircularLoader extrasmall />
+    }
 
     return (
         <>
@@ -26,14 +50,19 @@ export default function SharingAction({ dataStoreKey }: SharingActionProps) {
                 aria-label={i18n.t('Share')}
                 icon={<IconShare16 />}
                 name="share"
-                onClick={() => setOpenSharingDialog(true)}
+                onClick={() => {
+                    refetch()
+                }}
                 title={i18n.t('Share')}
             />
             {openSharingDialog && (
                 <SharingDialog
                     type={DATASTORE}
-                    id={keyMetaData?.['metadata']?.['id']}
-                    onClose={() => setOpenSharingDialog(false)}
+                    id={keyID}
+                    onClose={() => {
+                        setOpenSharingDialog(false)
+                        setKeyID(null)
+                    }}
                 />
             )}
         </>

--- a/src/components/table/SharingAction.tsx
+++ b/src/components/table/SharingAction.tsx
@@ -51,7 +51,11 @@ export default function SharingAction({
                 icon={<IconShare16 />}
                 name="share"
                 onClick={() => {
-                    refetch()
+                    if (keyID) {
+                        setOpenSharingDialog(true)
+                    } else {
+                        refetch()
+                    }
                 }}
                 title={i18n.t('Share')}
             />
@@ -59,10 +63,7 @@ export default function SharingAction({
                 <SharingDialog
                     type={DATASTORE}
                     id={keyID}
-                    onClose={() => {
-                        setOpenSharingDialog(false)
-                        setKeyID(null)
-                    }}
+                    onClose={() => setOpenSharingDialog(false)}
                 />
             )}
         </>


### PR DESCRIPTION
Addresses [comment](https://github.com/dhis2/datastore-app/pull/145#pullrequestreview-2629542716) on #145

---

**Description**
- This PR optimises sharing of datastore keys. Instead of actively fetching the IDs of all keys in a namespace on page load, we now fetch a key's ID only when its share button is clicked for the first time, and then store it for future use. This approach reduces the number of requests made at the same time. 

- This PR also handles some minor fixes:
   - [x] Fix table headers while scrolling through long tables of namespaces and keys
   - [x] Make Editor component uneditable if no key is selected
   - [x] [DHIS2-19177](https://dhis2.atlassian.net/browse/DHIS2-19177) - Validate against extremely long keys and namespaces by restricting character length to 255 characters.
  - [x] [BETA-306](https://dhis2.atlassian.net/browse/BETA-306) - Responsiveness of the panel header.


[DHIS2-19177]: https://dhis2.atlassian.net/browse/DHIS2-19177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BETA-306]: https://dhis2.atlassian.net/browse/BETA-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ