### PR TITLE
feat: show active line in the editor

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -3,6 +3,7 @@ import { linter, lintGutter } from '@codemirror/lint'
 import { search } from '@codemirror/search'
 import CodeMirror, { ViewUpdate } from '@uiw/react-codemirror'
 import React from 'react'
+import { activeLine } from './EditorActiveLinePanel'
 
 type EditorProps = {
     handleChange?: (value: string, viewUpdate: ViewUpdate) => void
@@ -22,8 +23,9 @@ const Editor = ({ value, handleChange }: EditorProps) => {
                     top: true,
                 }),
                 linter(jsonParseLinter(), {
-                    delay: 1000,
+                    delay: 500,
                 }),
+                activeLine(),
             ]}
             onChange={handleChange}
             autoFocus

--- a/src/components/editor/EditorActiveLinePanel.tsx
+++ b/src/components/editor/EditorActiveLinePanel.tsx
@@ -1,0 +1,41 @@
+import { EditorView, Extension, Panel, showPanel } from '@uiw/react-codemirror'
+
+const activeLinePanelTheme = EditorView.baseTheme({
+    '.cm-active-panel': {
+        padding: '5px',
+        backgroundColor: '#292c34',
+        color: '#acb4be',
+        borderTop: '1px solid #acb4be',
+    },
+})
+
+const trackCursorPosition = (view) => {
+    const pos = view.state.selection.main.head
+    const line = view.state.doc.lineAt(pos)
+    const column = pos - line.from + 1
+    return {
+        lineNumber: line.number,
+        column,
+    }
+}
+
+const activeLinePanel = (view: EditorView): Panel => {
+    const dom = document.createElement('div')
+    dom.className = 'cm-active-panel'
+    const { lineNumber, column } = trackCursorPosition(view)
+    dom.textContent = `Line: ${lineNumber}, Column: ${column}`
+    return {
+        dom,
+        update(viewUpdate) {
+            if (viewUpdate.docChanged || viewUpdate.selectionSet) {
+                const { lineNumber, column } = trackCursorPosition(viewUpdate)
+                dom.textContent = `Line: ${lineNumber}, Column: ${column}`
+            }
+        },
+    }
+}
+
+export const activeLine = (): Extension => [
+    showPanel.of(activeLinePanel),
+    activeLinePanelTheme,
+]

--- a/src/components/sections/EditSection.tsx
+++ b/src/components/sections/EditSection.tsx
@@ -7,8 +7,8 @@ import useCustomAlert from '../../hooks/useCustomAlert'
 import useDiscardAlert from '../../hooks/useDiscardAlert'
 import i18n from '../../locales'
 import { useEditContext } from '../context/EditContext'
+import Editor from '../editor/Editor'
 import EditPanelHeader from '../header/EditPanelHeader'
-import Editor from './Editor'
 
 const EditSection = ({ query }) => {
     const { key, namespace, store } = useParams()


### PR DESCRIPTION
This PR shows the user which line is active in the editor by tracking the cursor position. 

<img width="984" alt="Screenshot 2025-03-17 at 19 14 39" src="https://github.com/user-attachments/assets/cb1868f4-6f9e-4b49-9d67-ff55404e33c9" />
