### PR TITLE
fix: redirect to main page after deleting single key in namespace

### DIFF
--- a/src/components/sections/KeysDataSection.tsx
+++ b/src/components/sections/KeysDataSection.tsx
@@ -131,9 +131,7 @@ const KeysDataSection = ({ query }: KeysDataSectionProps) => {
                 ? `/${store}/edit/${currentNamespace}`
                 : `/${store}`
 
-            if (selectedKey === activeRow) {
-                navigate(navigatePath)
-            }
+            navigate(navigatePath)
 
             if (namespaceHasMultipleKeys) {
                 refetch({ id: currentNamespace })


### PR DESCRIPTION
Fixes [DHIS2-19262](https://dhis2.atlassian.net/browse/DHIS2-19262)

[DHIS2-19262]: https://dhis2.atlassian.net/browse/DHIS2-19262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ