### PR TITLE
chore: add coreApp property to d2 config

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -3,6 +3,7 @@ const config = {
     name: 'datastore',
     title: 'Datastore',
     id: 'c968eb49-01f5-4904-b4d3-f3785c6bfc09',
+    coreApp: true,
 
     minDHIS2Version: '2.41',
 


### PR DESCRIPTION
- Set coreApp to true in d2 config for v.41 and below to be able to use the new datastore app 