### PR TITLE
fix: handle numeric json payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@dhis2/app-runtime": "^3.13.1",
         "@dhis2/ui": "^10.5.0",
         "@uiw/react-codemirror": "^4.23.6",
+        "lossless-json": "^4.0.2",
         "prop-types": "^15.8.1"
     }
 }

--- a/src/components/sections/EditSection.tsx
+++ b/src/components/sections/EditSection.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import classes from '../../App.module.css'
 import useCustomAlert from '../../hooks/useCustomAlert'
 import i18n from '../../locales'
+import { parseEditorValue, stringifyEditorValue } from '../../utils/json-utils'
 import { useEditContext } from '../context/EditContext'
 import Editor from '../editor/Editor'
 import EditPanelHeader from '../header/EditPanelHeader'
@@ -60,7 +61,8 @@ const EditSection = ({ query }: EditSectionProps) => {
         }
 
         try {
-            body = JSON.parse(editorView.state.doc.toString())
+            body = parseEditorValue(editorView.state.doc.toString())
+
             await engine.mutate(
                 {
                     type: 'update' as const,
@@ -128,7 +130,7 @@ const EditSection = ({ query }: EditSectionProps) => {
                     </Center>
                 ) : (
                     <Editor
-                        value={JSON.stringify(data?.results, null, 4) || '{}'}
+                        value={stringifyEditorValue(data?.results) ?? '{}'}
                         setEditorView={setEditorView}
                     />
                 )}

--- a/src/utils/json-utils.ts
+++ b/src/utils/json-utils.ts
@@ -1,0 +1,24 @@
+import { isLosslessNumber, isSafeNumber, parse, stringify } from 'lossless-json'
+
+export function stringifyEditorValue(text) {
+    return stringify(
+        text,
+        (_, value) => {
+            if (typeof value === 'string') {
+                return isSafeNumber(value) ? Number(value) : value
+            }
+            return value
+        },
+        4
+    )
+}
+
+export function parseEditorValue(jsonText) {
+    return parse(jsonText, (_, value) => {
+        if (isLosslessNumber(value)) {
+            const num = value?.valueOf()
+            return typeof num === 'bigint' ? num.toString() : num
+        }
+        return value
+    })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8390,6 +8390,11 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lossless-json@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/lossless-json/-/lossless-json-4.0.2.tgz#f00c52815805d1421930a87e2670e27350958a3f"
+  integrity sha512-+z0EaLi2UcWi8MZRxA5iTb6m4Ys4E80uftGY+yG5KNFJb5EceQXOhdW/pWJZ8m97s26u7yZZAYMcKWNztSZssA==
+
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"


### PR DESCRIPTION
Fixes overflow issue highlighted in [DHIS2-19178](https://dhis2.atlassian.net/browse/DHIS2-19178)

This PR handles the input of large numbers into the JSON editor. The current issue is due to JS' limitations in handling large numbers without corrupting any of it. 

**Solution**:
- Preserve the structure of big numbers by converting them into strings. 
- New library: [lossless-json](https://www.npmjs.com/package/lossless-json)