### PR TITLE
feat(tree-view): modify colour of edit icons

### DIFF
--- a/src/components/editor/TreeEditor.tsx
+++ b/src/components/editor/TreeEditor.tsx
@@ -124,6 +124,7 @@ const TreeViewEditor = ({
                 displayObjectSize={true}
                 collapsed={1}
                 indentWidth={40}
+                highlightUpdates
                 editable={!loading}
                 onDelete={handleDelete}
                 onEdit={handleEdit}

--- a/src/components/editor/treeEditorTheme.ts
+++ b/src/components/editor/treeEditorTheme.ts
@@ -5,10 +5,11 @@ const customTheme = {
     '--w-rjv-background-color': '#292c34',
     '--w-rjv-line-color': 'transparent', // line colour
     '--w-rjv-arrow-color': '#818499',
-    '--w-rjv-edit-color': '',
+    '--w-rjv-edit-color': '#789849',
+    '--w-rjv-add-color': '#789849',
     '--w-rjv-info-color': '#818499',
     '--w-rjv-update-color': '',
-    '--w-rjv-copied-color': '',
+    '--w-rjv-copied-color': '#d7d7d7',
     '--w-rjv-copied-success-color': '',
     '--w-rjv-curlybraces-color': '#acb4be',
     '--w-rjv-colon-color': '#acb4be',

--- a/src/components/editor/treeEditorTheme.ts
+++ b/src/components/editor/treeEditorTheme.ts
@@ -5,7 +5,7 @@ const customTheme = {
     '--w-rjv-background-color': '#292c34',
     '--w-rjv-line-color': 'transparent', // line colour
     '--w-rjv-arrow-color': '#818499',
-    '--w-rjv-edit-color': '#789849',
+    '--w-rjv-edit-color': '#2196f3',
     '--w-rjv-add-color': '#789849',
     '--w-rjv-info-color': '#818499',
     '--w-rjv-update-color': '',


### PR DESCRIPTION
Implements [DHIS2-19882](https://dhis2.atlassian.net/browse/DHIS2-19882)

----

**Screenshot**
<img width="1121" height="234" alt="edit icons" src="https://github.com/user-attachments/assets/c4716b3e-e674-448d-b9cd-b6f6450d1b11" />


[DHIS2-19882]: https://dhis2.atlassian.net/browse/DHIS2-19882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ